### PR TITLE
Add stub managers and adjust scripts to compile

### DIFF
--- a/Assets/Scripts/Analytics/AnalyticsInitializationManager.cs
+++ b/Assets/Scripts/Analytics/AnalyticsInitializationManager.cs
@@ -147,7 +147,7 @@ namespace CuriousCity.Analytics
             GameObject player = GameObject.FindGameObjectWithTag("Player");
             if (player != null)
             {
-                var controller = player.GetComponent<Characters.FirstPersonController>();
+                var controller = player.GetComponent<CuriousCity.Core.FirstPersonController>();
                 if (controller == null)
                 {
                     Debug.LogWarning("[AnalyticsInit] FirstPersonController not found on player.");

--- a/Assets/Scripts/Analytics/InteractionAnalyzer.cs
+++ b/Assets/Scripts/Analytics/InteractionAnalyzer.cs
@@ -85,7 +85,7 @@ namespace CuriousCity.Analytics.Analyzers
             if (Physics.Raycast(ray, out hit, interactionRange, interactableLayer))
             {
                 // Check for the Gameplay.Interactions version (the one we're keeping)
-                var interactable = hit.collider.GetComponent<CuriousCityAutomated.Gameplay.Interactions.IInteractable>();
+                var interactable = hit.collider.GetComponent<CuriousCity.Core.IInteractable>();
                 
                 if (interactable != null)
                 {

--- a/Assets/Scripts/Components/Interactions/ArtifactInteractable.cs
+++ b/Assets/Scripts/Components/Interactions/ArtifactInteractable.cs
@@ -2,8 +2,7 @@ using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 using TMPro;
-using CuriousCity.Characters;  // Required for FirstPersonController
-using CuriousCity.Gameplay.Puzzles;  // For HistoricalMissionSceneManager
+using CuriousCity.Core;  // For FirstPersonController and mission manager
 using CuriousCity.Data;  // For ArtifactData
 using CuriousCity.Analytics;
 

--- a/Assets/Scripts/Components/Interactions/PuzzleTriggerDebugger.cs
+++ b/Assets/Scripts/Components/Interactions/PuzzleTriggerDebugger.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using CuriousCity.Gameplay.Puzzles;
+using CuriousCity.Core; // For HistoricalMissionSceneManager and puzzles
 
 namespace CuriousCity.Core
 {
@@ -62,7 +62,7 @@ namespace CuriousCity.Core
             if (!enableDebugLogging) return;
             
             // Check for player proximity
-            var player = FindFirstObjectByType<CuriousCityAutomated.Characters.FirstPersonController>();
+            var player = FindFirstObjectByType<CuriousCity.Core.FirstPersonController>();
             if (player != null)
             {
                 float distance = Vector3.Distance(transform.position, player.transform.position);
@@ -82,7 +82,7 @@ namespace CuriousCity.Core
             Gizmos.DrawWireSphere(transform.position, 1.5f);
             
             // Draw raycast direction from player camera
-            var player = FindFirstObjectByType<CuriousCityAutomated.Characters.FirstPersonController>();
+            var player = FindFirstObjectByType<CuriousCity.Core.FirstPersonController>();
             if (player != null)
             {
                 var camera = player.GetComponentInChildren<Camera>();
@@ -106,7 +106,7 @@ namespace CuriousCity.Core
             Debug.Log("[PuzzleTriggerDebugger] Testing puzzle trigger manually...");
             
             // Simulate interaction
-            var player = FindFirstObjectByType<CuriousCityAutomated.Characters.FirstPersonController>();
+            var player = FindFirstObjectByType<CuriousCity.Core.FirstPersonController>();
             if (player != null)
             {
                 puzzleTrigger.Interact(player);

--- a/Assets/Scripts/Components/Interactions/PuzzleTriggerInteractable.cs
+++ b/Assets/Scripts/Components/Interactions/PuzzleTriggerInteractable.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
-using CuriousCity.Characters;  // For FirstPersonController
-using CuriousCity.Gameplay.Puzzles;  // For HistoricalMissionSceneManager
+using CuriousCity.Core;  // For FirstPersonController and mission manager
 using CuriousCity.Analytics;
 
 namespace CuriousCity.Core

--- a/Assets/Scripts/Components/Interactions/PuzzleTriggerMasterManager.cs
+++ b/Assets/Scripts/Components/Interactions/PuzzleTriggerMasterManager.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
-using CuriousCity.Gameplay.Puzzles;
+using CuriousCity.Core;
 
 namespace CuriousCity.Core
 {

--- a/Assets/Scripts/Components/Interactions/PuzzleTriggerRegistry.cs
+++ b/Assets/Scripts/Components/Interactions/PuzzleTriggerRegistry.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
-using CuriousCity.Gameplay.Puzzles;
+using CuriousCity.Core;
 
 namespace CuriousCity.Core
 {

--- a/Assets/Scripts/Components/Interactions/PuzzleTriggerSetupHelper.cs
+++ b/Assets/Scripts/Components/Interactions/PuzzleTriggerSetupHelper.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using CuriousCity.Gameplay.Puzzles;
+using CuriousCity.Core;
 
 namespace CuriousCity.Core
 {

--- a/Assets/Scripts/Components/Puzzles/ChronaReactionHelper.cs
+++ b/Assets/Scripts/Components/Puzzles/ChronaReactionHelper.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using CuriousCityAutomated.Data;
 using CuriousCityAutomated.Core;
-using CuriousCity.Core;
+using CuriousCity.Core.Puzzles;
 using System.Linq;
 
 namespace CuriousCity.Core

--- a/Assets/Scripts/Components/Puzzles/MissionDataManager.cs
+++ b/Assets/Scripts/Components/Puzzles/MissionDataManager.cs
@@ -94,10 +94,10 @@ namespace CuriousCityAutomated.Core
             // Initialize with proper mission data if we have a reference
             if (missionManager != null && missionManager.missionData != null)
             {
-                currentMissionId = missionManager.missionData.missionId;
-                currentMissionName = missionManager.missionData.title;
-                historicalPeriod = missionManager.missionData.historicalPeriod;
-                totalPuzzlesInMission = missionManager.missionData.requiredPuzzleTypes.Count;
+                currentMissionId = missionManager.missionData.MissionId;
+                currentMissionName = missionManager.missionData.Title;
+                historicalPeriod = missionManager.missionData.HistoricalPeriod;
+                totalPuzzlesInMission = missionManager.missionData.RequiredPuzzleTypes.Count;
                 
                 // Update mission results with correct data
                 currentMissionResults.missionId = currentMissionId;

--- a/Assets/Scripts/Core/ChronaAI.cs
+++ b/Assets/Scripts/Core/ChronaAI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using CuriousCity.Data;
 
 namespace CuriousCity.Core
 {
@@ -165,7 +166,8 @@ namespace CuriousCity.Core
                     targetColor = Color.green;
                     break;
                 case EmotionalTone.Concerned:
-                    targetColor = Color.orange;
+                    // Unity doesn't define Color.orange by default
+                    targetColor = new Color(1f, 0.5f, 0f);
                     break;
                 case EmotionalTone.Excited:
                     targetColor = Color.magenta;
@@ -235,13 +237,18 @@ namespace CuriousCity.Core
             
             return chronaGO;
         }
+
+        // Placeholder methods referenced by other systems
+        public void OnMissionStarted(string missionId) { }
+        public void ProcessMissionChoices(List<PlayerChoice> choices) { }
+        public void TriggerMissionReflection(MissionResults results) { }
     }
 
     /// <summary>
     /// Represents Chrona's personality state and development
     /// </summary>
     [System.Serializable]
-    public class ChronaPersonalityState 
+    public class ChronaPersonalityState : MonoBehaviour
     {
         [Header("Core Traits")]
         public float logicalCore = 1.0f;
@@ -252,7 +259,7 @@ namespace CuriousCity.Core
         public float curiosityLevel = 0.5f;
         public float trustLevel = 0.3f;
         
-        public void UpdatePersonality(bool empatheticAction) 
+        public void UpdatePersonality(bool empatheticAction)
         {
             totalInteractions++;
             

--- a/Assets/Scripts/Core/SceneBuilder.cs
+++ b/Assets/Scripts/Core/SceneBuilder.cs
@@ -140,7 +140,7 @@ namespace CuriousCity.Core
             cameraGO.AddComponent<AudioListener>();
         }
         
-        static void ClearScene()
+        public static void ClearScene()
         {
             // Destroy all non-persistent objects
             foreach (GameObject go in FindObjectsOfType<GameObject>())
@@ -150,6 +150,13 @@ namespace CuriousCity.Core
                     DestroyImmediate(go);
                 }
             }
+        }
+
+        // Simple placeholder for additional missions
+        public static void BuildGreeceMission()
+        {
+            // For now reuse Egypt mission layout
+            BuildEgyptMission();
         }
     }
 }

--- a/Assets/Scripts/Managers/MissionManager.cs
+++ b/Assets/Scripts/Managers/MissionManager.cs
@@ -113,6 +113,9 @@ namespace CuriousCity.Core.Puzzles
             // Initial Chrona briefing
             StartCoroutine(InitialMissionBriefing());
         }
+
+        // Placeholder start method referenced by builders
+        public void StartMission(string missionType) { }
         
         private void InitializeExplorationZones()
         {

--- a/Assets/Scripts/Stubs/ProjectStubs.cs
+++ b/Assets/Scripts/Stubs/ProjectStubs.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using CuriousCity.Data;
+
+// Global dialogue choice used by analytics
+public class DialogueChoice
+{
+    public string choiceText;
+    public float relationshipChange;
+}
+
+namespace CuriousCity.Core
+{
+    // Simple crew manager placeholder
+    public class CrewManager : MonoBehaviour { }
+
+    // Handles crew relationship events with empty implementations
+    public class CrewInteractionManager : MonoBehaviour
+    {
+        public static event Action<string, float> OnRelationshipChanged;
+        public void RefreshCrewStatus() { }
+        public void TriggerMissionReactions(MissionResults results) { }
+    }
+
+    // Central data manager stub
+    public class GameDataManager : MonoBehaviour
+    {
+        private static GameDataManager _instance;
+        public static GameDataManager Instance => _instance;
+        private void Awake() { if (_instance == null) _instance = this; }
+        public object GetCurrentSaveData() => null;
+    }
+
+    // Placeholder for Ark systems control
+    public class ArkSystemsManager : MonoBehaviour
+    {
+        public static event Action OnSystemUpdate;
+        public Dictionary<string, object> GetSystemStates() => new();
+        public void ProcessMissionResults(MissionResults results) { }
+    }
+
+    // Bridge console manager stub
+    public class TimeConsoleManager : MonoBehaviour
+    {
+        public static event Action<string> OnMissionSelected;
+        public void HighlightAvailableMissions() { }
+        public void RefreshMissionList() { }
+    }
+
+    // Placeholder for upgrade manager
+    public class ArkUpgradeManager : MonoBehaviour
+    {
+        public void RefreshUpgradeOptions() { }
+        public void IntegrateArtifact(string artifactType) { }
+    }
+
+    // Basic historical mission scene manager used by many systems
+    public class HistoricalMissionSceneManager : MonoBehaviour
+    {
+        public HistoricalMissionData missionData;
+
+        public static event Action<string> OnPuzzleCompleted;
+        public static event Action<string> OnZoneExplored;
+        public static event Action<MissionResults> OnMissionCompleted;
+
+        public bool CanAccessArtifact() => true;
+        public void RegisterPuzzleCompletion(string puzzleType, PuzzleResults results)
+            => OnPuzzleCompleted?.Invoke(puzzleType);
+        public void RegisterZoneExploration(string zone)
+            => OnZoneExplored?.Invoke(zone);
+        public void CompleteMission(MissionResults results)
+            => OnMissionCompleted?.Invoke(results);
+        public void OnPuzzleTriggered(string puzzleType, Vector3 position) { }
+    }
+}
+
+// Provide alias namespace used in some scripts
+namespace CuriousCity.Gameplay.Puzzles
+{
+    public class HistoricalMissionSceneManager : CuriousCity.Core.HistoricalMissionSceneManager { }
+}


### PR DESCRIPTION
## Summary
- Add stub implementations for missing managers and data helpers
- Fix ChronaAI color usage and add placeholder mission methods
- Expose scene clearing and add placeholder mission build
- Update analytics and interaction scripts to use correct namespaces and mission data properties

## Testing
- ❌ `dotnet --info` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ff7351d08323bea0b9c4424016c5